### PR TITLE
Locking down the dependencies versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-flask
-sqlalchemy
-flask-graphql
-graphene
-graphene_sqlalchemy
+flask==1.0.2
+sqlalchemy==1.2.10
+flask-graphql==2.0.0
+graphene==2.1.3
+graphene_sqlalchemy==2.1.0


### PR DESCRIPTION
Simply just some hygiene, locking down the dependencies will help prevent weird bugs that will pop up for new contributors. 