### PR TITLE
Use Hydda tile server, as it is flatter and less busy.

### DIFF
--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -6,6 +6,11 @@ const GRAPHQL_URL = 'graphql';
 const QUERY =
   '{ allTrees(maxLat: {{maxLat}}, minLat: {{minLat}}, minLon: {{minLon}}, maxLon: {{maxLon}}) { latitude longitude nameCommon address street } }';
 
+const TILE_URL = 'https://{s}.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png';
+const MAX_ZOOM = 18;
+const ATTRIBUTION =
+  'Tiles courtesy of <a href="http://openstreetmap.se/" target="_blank">OpenStreetMap Sweden</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>';
+
 export default class LeafletWrapper extends Component {
   constructor() {
     super();
@@ -87,8 +92,9 @@ export default class LeafletWrapper extends Component {
         onViewportChanged={v => this.onViewportChanged(v)}
       >
         <TileLayer
-          attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution={ATTRIBUTION}
+          url={TILE_URL}
+          maxZoom={MAX_ZOOM}
         />
         {markerList}
       </Map>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,6 +1435,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.3:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 clean-css@4.1.x:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
@@ -5798,6 +5802,14 @@ react-dom@^16.4.1:
 react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
+
+react-foundation@^0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/react-foundation/-/react-foundation-0.9.6.tgz#1bd641d310173dd966e2eb33d7bb63168aef7aff"
+  dependencies:
+    classnames "^2.2.3"
+    fbjs "^0.8.16"
+    prop-types "^15.5.10"
 
 react-leaflet@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This tileset for the map is a bit less busy, allowing us to have the tree data stand out in sharper contrast. Chosen in consultation with @jessbee.