### PR TITLE
adjust zoom + map center point

### DIFF
--- a/public/js/Geolocation.js
+++ b/public/js/Geolocation.js
@@ -7,7 +7,7 @@ var app = this.app || {};
           appId: 'plVZ8ETLEQ8S',
           apiKey: '593b988f69febc8841d79bcdc768d5c8',
           container: document.querySelector('#address-input'),
-          insidePolygon: "34.045660, -118.914285, 34.354319, -118.529420, 34.075525, -117.715745, 33.678182, -118.008943,"
+          insidePolygon: "34.045660, -118.914285, 34.800174, -118.487658, 34.075525, -117.715745, 33.678182, -118.008943,"
         });
 
         var zoomToLatLng = function(latlng){

--- a/public/js/Geolocation.js
+++ b/public/js/Geolocation.js
@@ -7,7 +7,7 @@ var app = this.app || {};
           appId: 'plVZ8ETLEQ8S',
           apiKey: '593b988f69febc8841d79bcdc768d5c8',
           container: document.querySelector('#address-input'),
-          insidePolygon: "34.026488, -118.516895, 34.048822, -118.491788, 34.041779, -118.483893, 34.046615, -118.477840, 34.024744, -118.446215, 34.017025, -118.441751, 33.993856, -118.481530"
+          insidePolygon: "34.045660, -118.914285, 34.354319, -118.529420, 34.075525, -117.715745, 33.678182, -118.008943,"
         });
 
         var zoomToLatLng = function(latlng){

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -10,7 +10,7 @@ var app = this.app || {};
     this.markerMap = Object.create(null);
     this.highlightedMarker = null;
     this.trees   = [];
-    this.zoom    = 10.2;
+    this.zoom    = 8.6;
     this.fillOpacity = 0.75;
     this.selected = new Set();
     this.urlParams = new URLSearchParams(window.location.search);
@@ -18,7 +18,7 @@ var app = this.app || {};
     this.zoomOnClick = 18
 
     this.leafletMap = L.map('map', {
-      center: [34.0774236,-118.247072],
+      center: [34.144,-118.441],
       zoom: this.zoom,
       zoomControl: false,
       layers: [

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -10,7 +10,7 @@ var app = this.app || {};
     this.markerMap = Object.create(null);
     this.highlightedMarker = null;
     this.trees   = [];
-    this.zoom    = 14.2;
+    this.zoom    = 10.2;
     this.fillOpacity = 0.75;
     this.selected = new Set();
     this.urlParams = new URLSearchParams(window.location.search);
@@ -18,7 +18,7 @@ var app = this.app || {};
     this.zoomOnClick = 18
 
     this.leafletMap = L.map('map', {
-      center: [34.0215, -118.481],
+      center: [34.0774236,-118.247072],
       zoom: this.zoom,
       zoomControl: false,
       layers: [


### PR DESCRIPTION
<!-- if the linked issue should remain open after your PR is merged: -->
addresses #318 <!-- issue number here -->

# Motivation and context
as we expand coverage to other parts of LA county, we need to expand the extent of the the county visible when the map initially loads

<!-- please describe what problem your issue is solving -->

# Screenshots
| before | after |
|---|---|
|![Screen Shot 2020-08-08 at 8 10 22 AM](https://user-images.githubusercontent.com/22624609/89713811-081d4080-d94f-11ea-885d-86494847490c.png) <!-- before screenshot here --> | ![Screen Shot 2020-08-08 at 8 10 04 AM](https://user-images.githubusercontent.com/22624609/89713822-15d2c600-d94f-11ea-9622-42aabf03e447.png) <!-- after screenshot here --> |

# What I did
- in preparation to accommodate data about trees in other parts of LA county, I relocated the map's center point to LASHP and reduced the zoom <!-- list summary of changes made in this PR -->
- I updated the bounding box for the algolia address search (to coordinates at the edges of LA county)